### PR TITLE
BTAT-8713 Refactor to InFlightPredicate to allow/deny access to org name journey

### DIFF
--- a/app/common/SessionKeys.scala
+++ b/app/common/SessionKeys.scala
@@ -25,6 +25,6 @@ object SessionKeys {
   val prepopulationTradingNameKey: String = "vatDesignatoryPrepopulationTradingName"
   val tradingNameChangeSuccessful: String = "vatDesignatoryTradingNameChangeSuccessful"
 
-  val inFlightTradingNameChangeKey: String = "inFlightTradingNameChange"
-
+  val inFlightOrgDetailsKey: String = "vatDesignatoryInFlightOrganisationDetails"
+  val orgNameAccessPermittedKey: String = "vatDesignatoryOrganisationNameAccessPermitted"
 }

--- a/app/controllers/BaseController.scala
+++ b/app/controllers/BaseController.scala
@@ -16,7 +16,7 @@
 
 package controllers
 
-import controllers.predicates.inflight.{InFlightPredicate, InFlightPredicateComponents}
+import controllers.predicates.inflight.{InFlightPredicateComponents, InFlightPredicate}
 import controllers.predicates.{AuthPredicate, AuthPredicateComponents}
 import play.api.i18n.I18nSupport
 import play.api.mvc.MessagesControllerComponents
@@ -32,6 +32,10 @@ abstract class BaseController(implicit val mcc: MessagesControllerComponents,
   val routePrefix = "/vat-through-software/account/designatory"
 
   val inFlightTradingNamePredicate = new InFlightPredicate(
-    inFlightComps, routePrefix + controllers.tradingName.routes.WhatToDoController.show().url
+    inFlightComps, routePrefix + controllers.tradingName.routes.WhatToDoController.show().url, orgNameJourney = false
   )
+
+  val orgNameAccessPredicate = new InFlightPredicate(
+    inFlightComps, routePrefix + "/TODO", orgNameJourney = true
+  ) // TODO add in reverse route here for first action in journey
 }

--- a/app/controllers/businessTradingName/CheckYourAnswersController.scala
+++ b/app/controllers/businessTradingName/CheckYourAnswersController.scala
@@ -69,7 +69,7 @@ class CheckYourAnswersController @Inject() (checkYourAnswersView: CheckYourAnswe
           Some(routes.CheckYourAnswersController.updateTradingName().url)
         )
         Redirect(controllers.routes.ChangeSuccessController.tradingName())
-          .addingToSession(tradingNameChangeSuccessful -> "true", inFlightTradingNameChangeKey -> "true")
+          .addingToSession(tradingNameChangeSuccessful -> "true", inFlightOrgDetailsKey -> "true")
       case _ =>
         Redirect(controllers.tradingName.routes.CaptureTradingNameController.show())
     }

--- a/app/models/customerInformation/CustomerInformation.scala
+++ b/app/models/customerInformation/CustomerInformation.scala
@@ -26,7 +26,9 @@ case class CustomerInformation(pendingChanges: Option[PendingChanges],
                                organisationName: Option[String],
                                tradingName: Option[String],
                                contactPreference: Option[String],
-                               changeIndicators: Option[ChangeIndicators]) {
+                               changeIndicators: Option[ChangeIndicators],
+                               nameIsReadOnly: Option[Boolean],
+                               partyType: Option[String]) {
 
   val pendingTradingName: Option[String] = pendingChanges.flatMap(_.tradingName)
 
@@ -38,6 +40,10 @@ case class CustomerInformation(pendingChanges: Option[PendingChanges],
       case (None, None, None, orgName) => orgName
       case _ => tradingName
     }
+
+  val isValidPartyType: Boolean =
+    Seq("Z1", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "50",
+      "51", "52", "53", "54", "55", "58", "59", "60", "61", "62", "63").contains(partyType.getOrElse(""))
 }
 
 object CustomerInformation {
@@ -49,6 +55,8 @@ object CustomerInformation {
   private val tradingNamePath = JsPath \ "customerDetails" \ "tradingName"
   private val contactPreferencePath = JsPath \ "commsPreference"
   private val changeIndicatorsPath = JsPath \ "changeIndicators"
+  private val nameIsReadOnlyPath = JsPath \ "customerDetails" \ "nameIsReadOnly"
+  private val partyTypePath = JsPath \ "partyType"
 
   implicit val reads: Reads[CustomerInformation] = (
     pendingChangesPath.readNullable[PendingChanges].orElse(Reads.pure(None)) and
@@ -57,6 +65,8 @@ object CustomerInformation {
     organisationNamePath.readNullable[String].orElse(Reads.pure(None)) and
     tradingNamePath.readNullable[String].orElse(Reads.pure(None)) and
     contactPreferencePath.readNullable[String].orElse(Reads.pure(None)) and
-    changeIndicatorsPath.readNullable[ChangeIndicators].orElse(Reads.pure(None))
+    changeIndicatorsPath.readNullable[ChangeIndicators].orElse(Reads.pure(None)) and
+    nameIsReadOnlyPath.readNullable[Boolean].orElse(Reads.pure(None)) and
+    partyTypePath.readNullable[String].orElse(Reads.pure(None))
   )(CustomerInformation.apply _)
 }

--- a/it/connectors/VatSubscriptionConnectorISpec.scala
+++ b/it/connectors/VatSubscriptionConnectorISpec.scala
@@ -52,7 +52,9 @@ class VatSubscriptionConnectorISpec extends IntegrationBaseSpec {
     organisationName = Some("D Taylor's Cars"),
     tradingName = Some("DT Autos"),
     contactPreference = Some(ContactPreference.digital),
-    changeIndicators = Some(changeIndicators)
+    changeIndicators = Some(changeIndicators),
+    nameIsReadOnly = Some(false),
+    partyType = Some("1")
   )
 
   "Calling getCustomerInfo" when {

--- a/it/pages/BasePageISpec.scala
+++ b/it/pages/BasePageISpec.scala
@@ -28,7 +28,7 @@ trait BasePageISpec extends IntegrationBaseSpec {
     _.fold(Map.empty[String, String])(x => Map(SessionKeys.clientVrn -> x))
 
   def formatInflightChange: Option[String] => Map[String, String] =
-    _.fold(Map.empty[String, String])(x => Map(SessionKeys.inFlightTradingNameChangeKey -> x))
+    _.fold(Map.empty[String, String])(x => Map(SessionKeys.inFlightOrgDetailsKey -> x))
 
   def formatValidationTradingName: Option[String] => Map[String, String] =
     _.fold(Map.empty[String, String])(x => Map(SessionKeys.validationTradingNameKey -> x))

--- a/it/pages/tradingName/ChangeSuccessPageSpec.scala
+++ b/it/pages/tradingName/ChangeSuccessPageSpec.scala
@@ -20,6 +20,7 @@ import common.SessionKeys.{prepopulationTradingNameKey, tradingNameChangeSuccess
 import pages.BasePageISpec
 import play.api.http.Status
 import play.api.libs.ws.WSResponse
+import stubs.VatSubscriptionStub
 
 class ChangeSuccessPageSpec extends BasePageISpec {
 
@@ -39,6 +40,8 @@ class ChangeSuccessPageSpec extends BasePageISpec {
         "load successfully" in {
 
           given.user.isAuthenticated
+
+          VatSubscriptionStub.stubCustomerInfo
 
           val result = show
 

--- a/it/stubs/VatSubscriptionStub.scala
+++ b/it/stubs/VatSubscriptionStub.scala
@@ -25,7 +25,6 @@ import play.api.libs.json.{JsObject, Json}
 object VatSubscriptionStub extends WireMockMethods {
 
   private val getCustomerInfoUri: String = "/vat-subscription/([0-9]+)/full-information"
-  private val updateOrganisationDetailsUri: String = "/vat-subscription/([0-9]+)/organisationDetails"
 
   def stubCustomerInfo: StubMapping = {
     when(method = GET, uri = getCustomerInfoUri)
@@ -37,23 +36,8 @@ object VatSubscriptionStub extends WireMockMethods {
       .thenReturn(status = OK, body = emptyCustomerInfo)
   }
 
-  def stubUpdateOrganisationDetails: StubMapping = {
-    when(method = PUT, uri = updateOrganisationDetailsUri)
-      .thenReturn(status = OK, body = updateOrganisationDetailsJson)
-  }
-
-  def stubUpdateOrganisationDetailsNoMessage: StubMapping = {
-    when(method = PUT, uri = updateOrganisationDetailsUri)
-      .thenReturn(status = OK, body = updateOrganisationDetailsEmptyResponse)
-  }
-
   def stubCustomerInfoError: StubMapping = {
     when(method = GET, uri = getCustomerInfoUri)
-      .thenReturn(status = INTERNAL_SERVER_ERROR, body = Json.obj("fail" -> "nope"))
-  }
-
-  def stubUpdateOrganisationDetailsError: StubMapping = {
-    when(method = PUT, uri = updateOrganisationDetailsUri)
       .thenReturn(status = INTERNAL_SERVER_ERROR, body = Json.obj("fail" -> "nope"))
   }
 
@@ -65,19 +49,13 @@ object VatSubscriptionStub extends WireMockMethods {
       "firstName" -> "Dave",
       "lastName" -> "Taylor",
       "organisationName" -> "D Taylor's Cars",
-      "tradingName" -> "DT Autos"
+      "tradingName" -> "DT Autos",
+      "nameIsReadOnly" -> false
     ),
     "commsPreference" -> "DIGITAL",
-    "changeIndicators" -> changeIndicatorsModel
+    "changeIndicators" -> changeIndicatorsModel,
+    "partyType" -> "1"
   )
 
   val emptyCustomerInfo: JsObject = Json.obj("xxx" -> "xxx")
-
-  val updateOrganisationDetailsJson: JsObject = Json.obj(
-    "formBundle" -> "success"
-  )
-
-  val updateOrganisationDetailsEmptyResponse: JsObject = Json.obj(
-    "formBundle" -> ""
-  )
 }

--- a/test/assets/CustomerInfoConstants.scala
+++ b/test/assets/CustomerInfoConstants.scala
@@ -34,7 +34,7 @@ object CustomerInfoConstants {
   val pendingTradingNameModel: PendingChanges = PendingChanges(Some("New trading name"))
   val changeIndicatorsModel: ChangeIndicators = ChangeIndicators(true)
 
-  val minCustomerInfoModel: CustomerInformation = CustomerInformation(None, None, None, None, None, None, None)
+  val minCustomerInfoModel: CustomerInformation = CustomerInformation(None, None, None, None, None, None, None, None, None)
   val minCustomerInfoJson: JsObject = Json.obj()
 
   val fullCustomerInfoModel: CustomerInformation = CustomerInformation(
@@ -44,8 +44,12 @@ object CustomerInfoConstants {
     organisationName = Some("PepsiMac Ltd"),
     tradingName = Some("PepsiMac"),
     contactPreference = Some(ContactPreference.digital),
-    changeIndicators = Some(changeIndicatorsModel)
+    changeIndicators = Some(changeIndicatorsModel),
+    nameIsReadOnly = Some(false),
+    partyType = Some("1")
   )
+
+  val customerInfoNoPending: CustomerInformation = fullCustomerInfoModel.copy(changeIndicators = None)
 
   val fullCustomerInfoModelSameTradingName: CustomerInformation = fullCustomerInfoModel.copy(
     tradingName = Some("New trading name")
@@ -57,10 +61,12 @@ object CustomerInfoConstants {
       "firstName" -> "Pepsi",
       "lastName" -> "Mac",
       "organisationName" -> "PepsiMac Ltd",
-      "tradingName" -> "PepsiMac"
+      "tradingName" -> "PepsiMac",
+      "nameIsReadOnly" -> false
     ),
     "commsPreference" -> "DIGITAL",
-    "changeIndicators" -> Some(changeIndicatorsModel)
+    "changeIndicators" -> Some(changeIndicatorsModel),
+    "partyType" -> "1"
   )
 
   val updateOrganisationDetailsModel: UpdateOrganisationDetails =

--- a/test/controllers/predicates/inflight/InFlightPredicateSpec.scala
+++ b/test/controllers/predicates/inflight/InFlightPredicateSpec.scala
@@ -17,7 +17,7 @@
 package controllers.predicates.inflight
 
 import assets.CustomerInfoConstants._
-import common.SessionKeys.inFlightTradingNameChangeKey
+import common.SessionKeys.{inFlightOrgDetailsKey, orgNameAccessPermittedKey}
 import connectors.httpParsers.GetCustomerInfoHttpParser.GetCustomerInfoResponse
 import mocks.MockAuth
 import models.User
@@ -41,104 +41,271 @@ class InFlightPredicateSpec extends MockAuth {
 
   val inflightTradingNamePredicate = new InFlightPredicate(
     mockInFlightPredicateComponents,
-    "/redirect-location"
+    "/redirect-location",
+    orgNameJourney = false
+  )
+
+  val inflightOrgNamePredicate = new InFlightPredicate(
+    mockInFlightPredicateComponents,
+    "/redirect-location",
+    orgNameJourney = true
   )
 
   def inflightRequest(value: String): User[AnyContentAsEmpty.type] =
-    User("999999999")(request.withSession(inFlightTradingNameChangeKey -> value))
+    User("999999999")(request.withSession(inFlightOrgDetailsKey -> value))
+
+  def inflightRequestWithAccess(value: String, access: String): User[AnyContentAsEmpty.type] =
+    User("999999999")(request.withSession(inFlightOrgDetailsKey -> value, orgNameAccessPermittedKey -> access))
 
   val userWithoutSession: User[AnyContentAsEmpty.type] = User("999999999")(FakeRequest())
 
   "The InFlightPredicate" when {
 
-    "there is an inflight indicator in session" when {
+    "orgDetailsJourney is set to 'false'" when {
 
-      "the inflight indicator is set to a change value" should {
+      "there is an inflight indicator in session" when {
 
-        lazy val result = await(inflightTradingNamePredicate.refine(inflightRequest("true"))).left.get
-        lazy val document = Jsoup.parse(bodyOf(result))
+        "the inflight indicator is set to 'true'" should {
 
-        "return 409" in {
-          status(result) shouldBe Status.CONFLICT
+          lazy val result = await(inflightTradingNamePredicate.refine(inflightRequest("true"))).left.get
+          lazy val document = Jsoup.parse(bodyOf(result))
+
+          "return 409" in {
+            status(result) shouldBe Status.CONFLICT
+          }
+
+          "show the 'change pending' error page" in {
+            messages(document.title) shouldBe "You cannot request another change now - Business tax account - GOV.UK"
+          }
+
+          "not call the VatSubscriptionService" in {
+            verify(mockVatSubscriptionService, never())
+              .getCustomerInfo(any[String])(any[HeaderCarrier], any[ExecutionContext])
+          }
         }
 
-        "show the 'change pending' error page" in {
-          messages(document.title) shouldBe "You cannot request another change now - Business tax account - GOV.UK"
-        }
+        "the inflight indicator is set to 'false'" should {
 
-        "not call the VatSubscriptionService" in {
-          verify(mockVatSubscriptionService, never())
-            .getCustomerInfo(any[String])(any[HeaderCarrier], any[ExecutionContext])
+          lazy val result = await(inflightTradingNamePredicate.refine(inflightRequest("false")))
+
+          "allow the request to pass through the predicate" in {
+            result shouldBe Right(inflightRequest("false"))
+          }
+
+          "not call the VatSubscriptionService" in {
+            verify(mockVatSubscriptionService, never())
+              .getCustomerInfo(any[String])(any[HeaderCarrier], any[ExecutionContext])
+          }
         }
       }
 
-      "the inflight indicator is set to 'false'" should {
+      "there is no inflight indicator in session" when {
 
-        lazy val result = await(inflightTradingNamePredicate.refine(inflightRequest("false")))
+        "the user has an inflight trading name" should {
 
-        "allow the request to pass through the predicate" in {
-          result shouldBe Right(inflightRequest("false"))
+          lazy val result = {
+            setup()
+            await(inflightTradingNamePredicate.refine(userWithoutSession)).left.get
+          }
+          lazy val document = Jsoup.parse(bodyOf(result))
+
+          "return 409" in {
+            status(result) shouldBe Status.CONFLICT
+          }
+
+          "add the inflight indicator 'true' to session" in {
+            session(result).get(inFlightOrgDetailsKey) shouldBe Some("true")
+          }
+
+          "show the 'change pending' error page" in {
+            messages(document.title) shouldBe "You cannot request another change now - Business tax account - GOV.UK"
+          }
         }
 
-        "not call the VatSubscriptionService" in {
-          verify(mockVatSubscriptionService, never())
-            .getCustomerInfo(any[String])(any[HeaderCarrier], any[ExecutionContext])
+        "the user has no inflight information" should {
+
+          lazy val result = {
+            setup(Right(minCustomerInfoModel))
+            await(inflightTradingNamePredicate.refine(userWithoutSession)).left.get
+          }
+
+          "return 303" in {
+            status(result) shouldBe Status.SEE_OTHER
+          }
+
+          "redirect the user to the predicate's redirect URL" in {
+            redirectLocation(result) shouldBe Some("/redirect-location")
+          }
+
+          "add the inflight indicator 'false' to session" in {
+            session(result).get(inFlightOrgDetailsKey) shouldBe Some("false")
+          }
+        }
+
+        "the service call fails" should {
+
+          lazy val result = {
+            setup(Left(ErrorModel(Status.INTERNAL_SERVER_ERROR, "error")))
+            await(inflightTradingNamePredicate.refine(userWithoutSession)).left.get
+          }
+
+          "return 500" in {
+            status(result) shouldBe Status.INTERNAL_SERVER_ERROR
+          }
         }
       }
     }
 
-    "there is no inflight indicator in session" when {
+    "orgDetailsJourney is set to 'true'" when {
 
-      "the user has an inflight trading name" should {
+      "there is an access permission of 'true' in session" when {
 
-        lazy val result = {
-          setup()
-          await(inflightTradingNamePredicate.refine(userWithoutSession)).left.get
+        "the inflight indicator is set to 'true'" should {
+
+          lazy val result = await(inflightOrgNamePredicate.refine(inflightRequestWithAccess("true", "true"))).left.get
+          lazy val document = Jsoup.parse(bodyOf(result))
+
+          "return 409" in {
+            status(result) shouldBe Status.CONFLICT
+          }
+
+          "show the 'change pending' error page" in {
+            messages(document.title) shouldBe "You cannot request another change now - Business tax account - GOV.UK"
+          }
+
+          "not call the VatSubscriptionService" in {
+            verify(mockVatSubscriptionService, never())
+              .getCustomerInfo(any[String])(any[HeaderCarrier], any[ExecutionContext])
+          }
         }
-        lazy val document = Jsoup.parse(bodyOf(result))
 
-        "return 409" in {
-          status(result) shouldBe Status.CONFLICT
-        }
+        "the inflight indicator is set to 'false'" should {
 
-        "add the inflight indicator 'true' to session" in {
-          session(result).get(inFlightTradingNameChangeKey) shouldBe Some("true")
-        }
+          lazy val result = await(inflightOrgNamePredicate.refine(inflightRequestWithAccess("false", "true")))
 
-        "show the 'change pending' error page" in {
-          messages(document.title) shouldBe "You cannot request another change now - Business tax account - GOV.UK"
+          "allow the request to pass through the predicate" in {
+            result shouldBe Right(inflightRequestWithAccess("false", "true"))
+          }
+
+          "not call the VatSubscriptionService" in {
+            verify(mockVatSubscriptionService, never())
+              .getCustomerInfo(any[String])(any[HeaderCarrier], any[ExecutionContext])
+          }
         }
       }
 
-      "the user has no inflight information" should {
+      "there is an access permission of 'false' in session, regardless of inflight indicator" should {
 
         lazy val result = {
           setup(Right(minCustomerInfoModel))
-          await(inflightTradingNamePredicate.refine(userWithoutSession)).left.get
+          await(inflightOrgNamePredicate.refine(inflightRequestWithAccess("false", "false"))).left.get
         }
 
         "return 303" in {
           status(result) shouldBe Status.SEE_OTHER
         }
 
-        "redirect the user to the predicate's redirect URL" in {
-          redirectLocation(result) shouldBe Some("/redirect-location")
-        }
-
-        "add the inflight indicator 'false' to session" in {
-          session(result).get(inFlightTradingNameChangeKey) shouldBe Some("false")
+        "redirect the user to manage VAT overview page" in {
+          redirectLocation(result) shouldBe Some(mockConfig.manageVatSubscriptionServicePath)
         }
       }
 
-      "the service call fails" should {
+      "there is no access permission in session" when {
 
-        lazy val result = {
-          setup(Left(ErrorModel(Status.INTERNAL_SERVER_ERROR, "error")))
-          await(inflightTradingNamePredicate.refine(userWithoutSession)).left.get
+        "the user has the correct customer info to allow them into the journey" should {
+
+          lazy val result = {
+            setup(Right(customerInfoNoPending))
+            await(inflightOrgNamePredicate.refine(userWithoutSession)).left.get
+          }
+
+          "return 303" in {
+            status(result) shouldBe Status.SEE_OTHER
+          }
+
+          "redirect the user to the predicate's redirect URL" in {
+            redirectLocation(result) shouldBe Some("/redirect-location")
+          }
+
+          "add the access permission 'true' to session" in {
+            session(result).get(orgNameAccessPermittedKey) shouldBe Some("true")
+          }
+
+          "add the inflight indicator 'false' to session" in {
+            session(result).get(inFlightOrgDetailsKey) shouldBe Some("false")
+          }
         }
 
-        "return 500" in {
-          status(result) shouldBe Status.INTERNAL_SERVER_ERROR
+        "the user has an invalid party type" should {
+
+          lazy val result = {
+            setup(Right(customerInfoNoPending.copy(partyType = Some("F"))))
+            await(inflightOrgNamePredicate.refine(userWithoutSession)).left.get
+          }
+
+          "return 303" in {
+            status(result) shouldBe Status.SEE_OTHER
+          }
+
+          "redirect the user to manage VAT overview page" in {
+            redirectLocation(result) shouldBe Some(mockConfig.manageVatSubscriptionServicePath)
+          }
+
+          "add the access permission 'false' to session" in {
+            session(result).get(orgNameAccessPermittedKey) shouldBe Some("false")
+          }
+
+          "add the inflight indicator 'false' to session" in {
+            session(result).get(inFlightOrgDetailsKey) shouldBe Some("false")
+          }
+        }
+
+        "the user does not have an organisation name" should {
+
+          lazy val result = {
+            setup(Right(customerInfoNoPending.copy(organisationName = None)))
+            await(inflightOrgNamePredicate.refine(userWithoutSession)).left.get
+          }
+
+          "return 303" in {
+            status(result) shouldBe Status.SEE_OTHER
+          }
+
+          "redirect the user to manage VAT overview page" in {
+            redirectLocation(result) shouldBe Some(mockConfig.manageVatSubscriptionServicePath)
+          }
+
+          "add the access permission 'false' to session" in {
+            session(result).get(orgNameAccessPermittedKey) shouldBe Some("false")
+          }
+
+          "add the inflight indicator 'false' to session" in {
+            session(result).get(inFlightOrgDetailsKey) shouldBe Some("false")
+          }
+        }
+
+        "the user does not have nameIsReadOnly set to 'false'" should {
+
+          lazy val result = {
+            setup(Right(customerInfoNoPending.copy(nameIsReadOnly = Some(true))))
+            await(inflightOrgNamePredicate.refine(userWithoutSession)).left.get
+          }
+
+          "return 303" in {
+            status(result) shouldBe Status.SEE_OTHER
+          }
+
+          "redirect the user to manage VAT overview page" in {
+            redirectLocation(result) shouldBe Some(mockConfig.manageVatSubscriptionServicePath)
+          }
+
+          "add the access permission 'false' to session" in {
+            session(result).get(orgNameAccessPermittedKey) shouldBe Some("false")
+          }
+
+          "add the inflight indicator 'false' to session" in {
+            session(result).get(inFlightOrgDetailsKey) shouldBe Some("false")
+          }
         }
       }
     }

--- a/test/mocks/MockAuth.scala
+++ b/test/mocks/MockAuth.scala
@@ -28,9 +28,7 @@ import uk.gov.hmrc.auth.core.retrieve.{Retrieval, ~}
 import utils.TestUtil
 import assets.BaseTestConstants._
 import audit.AuditingService
-import controllers.predicates.inflight.{InFlightPredicate, InFlightPredicateComponents}
-import models.User
-import play.api.mvc.Result
+import controllers.predicates.inflight.InFlightPredicateComponents
 import views.html.errors.{InFlightChangeView, NotSignedUpView, SessionTimeoutView}
 import views.html.errors.agent.UnauthorisedAgentView
 
@@ -83,11 +81,8 @@ trait MockAuth extends TestUtil with BeforeAndAfterEach with MockitoSugar with M
   implicit val mockInFlightPredicateComponents: InFlightPredicateComponents = new InFlightPredicateComponents(
     mockVatSubscriptionService,
     mockErrorHandler,
-    messagesApi,
     mcc,
     inFlightChangeView,
-    mockConfig,
-    ec
   )
 
   val mockAuthPredicate: AuthPredicate =
@@ -96,19 +91,6 @@ trait MockAuth extends TestUtil with BeforeAndAfterEach with MockitoSugar with M
     )
 
   val mockAuditingService: AuditingService = mock[AuditingService]
-
-  val mockInflightPPOBPredicate: InFlightPredicate = {
-
-    object MockPredicate extends InFlightPredicate(
-      mockInFlightPredicateComponents,
-      "/redirect-location"
-    ) {
-      override def refine[A](request: User[A]): Future[Either[Result, User[A]]] =
-        Future.successful(Right(User(vrn)(request)))
-    }
-
-    MockPredicate
-  }
 
   def mockIndividualAuthorised(): OngoingStubbing[Future[~[Option[AffinityGroup], Enrolments]]] =
     setupAuthResponse(Future.successful(

--- a/test/models/customerInformation/CustomerInformationSpec.scala
+++ b/test/models/customerInformation/CustomerInformationSpec.scala
@@ -85,4 +85,15 @@ class CustomerInformationSpec extends UnitSpec {
       }
     }
   }
+
+  ".isValidPartyType" should {
+
+    "return true if the value is in the list of valid types" in {
+      fullCustomerInfoModel.isValidPartyType shouldBe true
+    }
+
+    "return false if the value is not in the list of valid types" in {
+      minCustomerInfoModel.isValidPartyType shouldBe false
+    }
+  }
 }

--- a/test/utils/TestUtil.scala
+++ b/test/utils/TestUtil.scala
@@ -48,7 +48,7 @@ trait TestUtil extends UnitSpec with GuiceOneAppPerSuite with MaterializerSuppor
   val testTradingName = "Test Trading Name"
 
   implicit lazy val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest().withSession(
-    inFlightTradingNameChangeKey -> "false")
+    inFlightOrgDetailsKey -> "false")
 
   lazy val requestWithTradingName: FakeRequest[AnyContentAsEmpty.type] =
     request.withSession(prepopulationTradingNameKey -> testTradingName)


### PR DESCRIPTION
The small change to `TradingNameChangeSuccessPageSpec` is to prevent wiremock complaints as one call to vat subscription was not being stubbed there, even though it does not change the outcome of the test (this issue was pointed out by Sheila).